### PR TITLE
Function to add a header to the Guzzle HTTP client

### DIFF
--- a/src/RequestBase.php
+++ b/src/RequestBase.php
@@ -36,8 +36,7 @@ class RequestBase
     protected $aRequestData = [
         'base_uri' => 'https://checkout.buckaroo.nl/json/',
         'headers' => [
-            'Content-Type' => 'application/json',
-            'culture' => 'nl-NL'
+            'Content-Type' => 'application/json'
         ],
     ];
 
@@ -70,6 +69,19 @@ class RequestBase
     {
         $this->bTesting = true;
         $this->aRequestData['base_uri'] = 'https://testcheckout.buckaroo.nl/json/';
+
+        return $this;
+    }
+
+    /**
+     * Add a header to the Guzzle HTTP client
+     *
+     * @param $sHeaderKey
+     * @param $sHeaderValue
+     */
+    public function addClientHeader($sHeaderKey, $sHeaderValue)
+    {
+        $this->aRequestData['headers'][$sHeaderKey] = $sHeaderValue;
 
         return $this;
     }


### PR DESCRIPTION
I've added this function so I can set the 'culture' header for the request.

See https://testcheckout.buckaroo.nl/json/Docs/Authentication for other headers that are available.